### PR TITLE
[PKG-2224][CVE-257] CVE-2022-24713 patch update regex

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,7 @@ build:
     - set RUST_BACKTRACE=1  # [win]
     # PKG-2224: CVE-2022-24713 impacted regex<1.5.5
     # the next line can be removed on the next version
-    - cargo update -p regex
+    - cargo update -p regex --precise 1.8.4
     - cargo build --release -v
     - $STRIP target/release/rg  # [not win]
     - mkdir $PREFIX/bin  # [not win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,9 +10,12 @@ source:
   sha256: 0fb17aaf285b3eee8ddab17b833af1e190d73de317ff9648751ab0660d763ed2
 
 build:
-  number: 0
+  number: 1
   script:
     - set RUST_BACKTRACE=1  # [win]
+    # PKG-2224: CVE-2022-24713 impacted regex<1.5.5
+    # the next line can be removed on the next version
+    - cargo update -p regex
     - cargo build --release -v
     - $STRIP target/release/rg  # [not win]
     - mkdir $PREFIX/bin  # [not win]


### PR DESCRIPTION
[PKG-2224] and [CVE-257] with anaconda-distribution/cvetool#736

- move old folder feedstock to this new repo
- [CVE-2022-24713] patch update regex
- [CVE-2022-24713] affects `regex<1.5.5` [see discussion here](https://anaconda.slack.com/archives/C02K52E033M/p1686328841177849).
- [`regex=1.5.4` is in Cargo.lock](https://github.com/BurntSushi/ripgrep/blob/af6b6c543b224d348a8876f0c06245d9ea7929c5/Cargo.lock) for release `13.0.0` (bumped later on in the upstream but with no release issued).
- fixed with `cargo update -p regex` in the script.


Note: 
1. fixed with `cargo update -p regex` in the script: the build resolves to `1.5.5` at this point in time, but if we like to pin it strictly to `1.5.5`, then we should use `cargo update -p regex --precise 1.5.5`.
1. this is a new repo moved from an old folder. It looks pretty empty, there is only a `recipe` folder and a newly created `readme`. If something else is missing (recipe's license?) please let me know.

[CVE-2022-24713]: https://nvd.nist.gov/vuln/detail/cve-2022-24713
[PKG-2224]: https://anaconda.atlassian.net/browse/PKG-2224?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[CVE-257]: https://anaconda.atlassian.net/browse/CVE-257?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ