### PR TITLE
Rebuild for s390x

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,7 @@ source:
   sha256: 0fb17aaf285b3eee8ddab17b833af1e190d73de317ff9648751ab0660d763ed2
 
 build:
+  # trigger 1
   number: 1
   script:
     - set RUST_BACKTRACE=1  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,8 +10,7 @@ source:
   sha256: 0fb17aaf285b3eee8ddab17b833af1e190d73de317ff9648751ab0660d763ed2
 
 build:
-  # trigger 1
-  number: 1
+  number: 2
   script:
     - set RUST_BACKTRACE=1  # [win]
     # PKG-2224: CVE-2022-24713 impacted regex<1.5.5


### PR DESCRIPTION
ripgrep 13.0.0

**Destination channel:** defaults for linux-s390x

### Links

- [PKG-2324](https://anaconda.atlassian.net/browse/PKG-2324)


### Explanation of changes:

- Rebuild for s390x (missing artifacts) to address  CVE-2022-24713 with a score of 7.5


[PKG-2324]: https://anaconda.atlassian.net/browse/PKG-2324?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ