### PR TITLE
ripgrep 14.1.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,13 @@
+BSD 3-clause license
+Copyright (c) 2015-2024, Anaconda
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the copyright holder nor the names of its contributors may be used to endorse or promote products derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
-# ripgrep-feedstock
-ripgrep is a line-oriented search tool that recursively searches the current directory for a regex pattern.
+About ripgrep-feedstock
+=======================
+
+Feedstock license: [BSD-3-Clause](LICENSE)
+
+Home: https://github.com/BurntSushi/ripgrep
+
+Package license: MIT
+
+Summary: ripgrep recursively searches directories for a regex pattern
+
+
+Current release info
+====================
+
+| Name | Downloads | Version | Platforms |
+| --- | --- | --- | --- |
+| [![Conda Recipe](https://img.shields.io/badge/recipe-ripgrep-green.svg)](https://anaconda.org/anaconda/ripgrep) | [![Conda Downloads](https://img.shields.io/conda/dn/anaconda/ripgrep.svg)](https://anaconda.org/anaconda/ripgrep) | [![Conda Version](https://img.shields.io/conda/vn/anaconda/ripgrep.svg)](https://anaconda.org/anaconda/ripgrep) | [![Conda Platforms](https://img.shields.io/conda/pn/anaconda/ripgrep.svg)](https://anaconda.org/anaconda/ripgrep) |
+
+Installing ripgrep
+==================
+
+Installing `ripgrep` from the main channel can be achieved by:
+
+```
+conda install ripgrep
+```
+
+It is possible to list all of the versions of `ripgrep` available on your platform with `conda`:
+
+```
+conda search ripgrep
+```

--- a/recipe/conda_build_config.yaml
+++ b/recipe/conda_build_config.yaml
@@ -1,0 +1,9 @@
+rust_compiler:
+  - rust
+rust_compiler_version:
+  - 1.76.0
+# use {{ compiler('rust-gnu') }} when requiring a build using the m2w64-toolchain
+rust_gnu_compiler:             # [win]
+  - rust-gnu                   # [win]
+rust_gnu_compiler_version:     # [win]
+  - 1.76.0                     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = '13.0.0' %}
+{% set version = '14.1.0' %}
 {% set name = 'ripgrep' %}
 
 package:
@@ -7,15 +7,13 @@ package:
 
 source:
   url: https://github.com/BurntSushi/{{ name }}/archive/{{ version }}.tar.gz
-  sha256: 0fb17aaf285b3eee8ddab17b833af1e190d73de317ff9648751ab0660d763ed2
+  sha256: 33c6169596a6bbfdc81415910008f26e0809422fda2d849562637996553b2ab6
 
 build:
-  number: 2
+  number: 0
   script:
     - set RUST_BACKTRACE=1  # [win]
-    # PKG-2224: CVE-2022-24713 impacted regex<1.5.5
-    # the next line can be removed on the next version
-    - cargo update -p regex --precise 1.8.4
+    - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
     - cargo build --release -v
     - $STRIP target/release/rg  # [not win]
     - mkdir $PREFIX/bin  # [not win]
@@ -29,6 +27,7 @@ requirements:
   build:
     - {{ compiler('rust') }}  # [not win]
     - {{ compiler('rust-gnu') }}  # [win]
+    - cargo-bundle-licenses
 
 test:
   commands:
@@ -39,9 +38,9 @@ about:
   dev_url: https://github.com/BurntSushi/ripgrep
   doc_url: https://github.com/BurntSushi/ripgrep
   summary: ripgrep recursively searches directories for a regex pattern while respecting your gitignore
-  description: |    
+  description: |
     ripgrep is a line-oriented search tool that recursively searches the current directory for a regex pattern.
   license: MIT AND Unlicense
   license_family: Other
-  license_file: 
+  license_file:
     - LICENSE-MIT

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,8 +14,7 @@ build:
   script:
     - set RUST_BACKTRACE=1  # [win]
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
-    # # build statically linked binary with Rust, see https://github.com/BurntSushi/ripgrep?tab=readme-ov-file#building
-    - cargo install --locked --features pcre2 --root "$PREFIX" --path .
+    - cargo build --release -v
     - $STRIP target/release/rg  # [not win]
     - mkdir $PREFIX/bin  # [not win]
     - mkdir %PREFIX%\Library\mingw-w64\bin  # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,8 @@ build:
   script:
     - set RUST_BACKTRACE=1  # [win]
     - cargo-bundle-licenses --format yaml --output THIRDPARTY.yml
-    - cargo build --release -v
+    # # build statically linked binary with Rust, see https://github.com/BurntSushi/ripgrep?tab=readme-ov-file#building
+    - cargo install --locked --features pcre2 --root "$PREFIX" --path .
     - $STRIP target/release/rg  # [not win]
     - mkdir $PREFIX/bin  # [not win]
     - mkdir %PREFIX%\Library\mingw-w64\bin  # [win]


### PR DESCRIPTION
**Destination channel:** main

### Links

- [PKG-3672](https://anaconda.atlassian.net/browse/PKG-3672) 
- [Upstream repository](https://github.com/BurntSushi/ripgrep/tree/14.1.0)

### Explanation of changes:

- Add feedstock's license
- Reset the build number to 0
- Add `cargo-bundle-licenses`


[PKG-3672]: https://anaconda.atlassian.net/browse/PKG-3672?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ