### PR TITLE
ripgrep rebuild win-arm64

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -17,14 +17,13 @@ build:
     - cargo build --release -v
     - $STRIP target/release/rg  # [not win]
     - mkdir $PREFIX/bin  # [not win]
-    - mkdir %PREFIX%\Library\mingw-w64\bin  # [win]
+    - mkdir %PREFIX%\Library\bin  # [win]
     - cp target/release/rg $PREFIX/bin/rg  # [not win]
-    - copy target\release\rg.exe %PREFIX%\Library\mingw-w64\bin\rg.exe  # [win]
+    - copy target\release\rg.exe %PREFIX%\Library\bin\rg.exe  # [win]
 
 requirements:
   build:
-    - {{ compiler('rust') }}  # [not win]
-    - {{ compiler('rust-gnu') }}  # [win]
+    - {{ compiler('rust') }}
     - cargo-bundle-licenses
 
 test:


### PR DESCRIPTION
ripgrep rebuild with win-arm64 support

**Destination channel:** defaults

### Links

- [PKG-15376](https://anaconda.atlassian.net/browse/PKG-15376) 

### Explanation of changes:

- Bump build number
- Use regular rust compiler instead of gnu. 


[PKG-15376]: https://anaconda.atlassian.net/browse/PKG-15376?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ